### PR TITLE
Fix world mismatch exception in PlayerDeathEvent handler

### DIFF
--- a/src/main/java/fr/xyness/SCS/Listeners/PaperClaimEvents.java
+++ b/src/main/java/fr/xyness/SCS/Listeners/PaperClaimEvents.java
@@ -101,26 +101,27 @@ public class PaperClaimEvents implements Listener {
 
     	}
     }
-    
+
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
-    	if(instance.isFolia()) {
-    		Player player = event.getPlayer();
-    		Location respawnLocation = player.getRespawnLocation() == null ? player.getWorld().getSpawnLocation() : player.getRespawnLocation();
-    		Bukkit.getAsyncScheduler().runAtFixedRate(instance, task -> {
-				if(player != null && player.isOnline()) {
-					if(!player.isDead()) {
-						instance.executeSync(() -> {
-				    		PlayerPostRespawnEvent e = new PlayerPostRespawnEvent(player,respawnLocation, false);
-				    		Bukkit.getPluginManager().callEvent(e);
-						});
-						task.cancel();
-					}
-				} else {
-					task.cancel();
-				}
-    		}, 250, 250, TimeUnit.MILLISECONDS);
-    	}
+        if(instance.isFolia()) {
+            Player player = event.getPlayer();
+
+            Bukkit.getAsyncScheduler().runAtFixedRate(instance, task -> {
+                if(player != null && player.isOnline()) {
+                    if(!player.isDead()) {
+                        instance.executeSync(() -> {
+                            Location currentLocation = player.getLocation();
+                            PlayerPostRespawnEvent e = new PlayerPostRespawnEvent(player, currentLocation, false);
+                            Bukkit.getPluginManager().callEvent(e);
+                        });
+                        task.cancel();
+                    }
+                } else {
+                    task.cancel();
+                }
+            }, 250, 250, TimeUnit.MILLISECONDS);
+        }
     }
     
 	/**


### PR DESCRIPTION
This PR addresses an IllegalStateException that occurs when a player dies in the Nether dimension. The exception happens because the plugin attempts to get a respawn location while the player is still in the Nether, causing a world mismatch.

Changes:
- Removed code that attempts to get respawn location during death event
- Modified the event handler to wait until player has fully respawned
- Now uses the player's current location after respawn instead of attempting to predict it
- Eliminates the world mismatch exception by avoiding cross-dimensional location requests

Fixes issue #44 