### PR TITLE
Configurable regex for description

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "fr.xyness"
-version = "1.11.6.1"
+version = "1.11.7.0"
 
 java {
     toolchain {

--- a/langs/en_US.yml
+++ b/langs/en_US.yml
@@ -140,7 +140,7 @@ world-list-changeda-via-command: "§fWorld §e%name%§f removed from §edisabled
 cant-add-member-anymore: "§cYou have reached the maximum number of members per claim."
 you-cannot-use-this-name: "§cYou cannot use 'claim-' in your new claim name."
 incorrect-characters-name: "§cYou must use a name with only letters and numbers."
-incorrect-characters-description: "§cYou must use a description with only letters and numbers."
+incorrect-characters-description: "§cThe provided description contains illegal characters."
 claim-not-an-admin-claim: "§cThis claim is not a protected area."
 not-using-database: "§cThe database is disabled in config.yml."
 member-limit-must-be-positive: "§cThe member limit must be positive."

--- a/langs/fr_FR.yml
+++ b/langs/fr_FR.yml
@@ -119,7 +119,7 @@ world-list-changeda-via-command: "§fMonde §e%name%§f retiré des §emondes d�
 cant-add-member-anymore: "§cVous avez atteint le nombre maximum de membres par claim."
 you-cannot-use-this-name: "§cVous ne pouvez pas utiliser 'claim-' dans votre nouveau nom de claim."
 incorrect-characters-name: "§cVous devez utiliser un nom avec seulement des lettres et des chiffres."
-incorrect-characters-description: "§cVous devez utiliser une description avec seulement des lettres et des chiffres."
+incorrect-characters-description: "§cLa description fournie contient des caractères illégaux."
 claim-not-an-admin-claim: "§cCe claim n'est pas une zone protégée."
 not-using-database: "§cLa base de données est désactivée dans config.yml."
 member-limit-must-be-positive: "§cLa limite de membres doit être positive."

--- a/langs/pt_BR.yml
+++ b/langs/pt_BR.yml
@@ -138,7 +138,7 @@ world-list-changeda-via-command: "§fMundo §e%name%§f removido dos §emundos d
 cant-add-member-anymore: "§cVocê atingiu o número máximo de membros por claim."
 you-cannot-use-this-name: "§cVocê não pode usar 'claim-' no seu novo nome de claim."
 incorrect-characters-name: "§cVocê deve usar um nome com apenas letras e números."
-incorrect-characters-description: "§cVocê deve usar uma descrição com apenas letras e números."
+incorrect-characters-description: "§cA descrição fornecida contém caracteres ilegais."
 claim-not-an-admin-claim: "§cEste claim não é uma área protegida."
 not-using-database: "§cO banco de dados está desativado no config.yml."
 member-limit-must-be-positive: "§cO limite de membros deve ser positivo."

--- a/langs/vi_VN.yml
+++ b/langs/vi_VN.yml
@@ -139,8 +139,7 @@ cant-add-member-anymore: §cBạn đã đạt được số lượng thành viê
 you-cannot-use-this-name: §cBạn không thể chiếm đóng mới trong khi khu vực đang chiếm
   đóng.
 incorrect-characters-name: §cBạn phải sử dụng tên chỉ với các chữ cái và số.
-incorrect-characters-description: §cBạn phải sử dụng một mô tả chỉ với các chữ cái
-  và số.
+incorrect-characters-description: §cMô tả được cung cấp có chứa ký tự không hợp lệ.
 claim-not-an-admin-claim: §cKhu vực này không phải là một khu vực được bảo vệ.
 not-using-database: §cCơ sở dữ liệu bị vô hiệu hóa config.yml.
 member-limit-must-be-positive: §cGiới hạn thành viên phải tích cực.

--- a/langs/zh_CN.yml
+++ b/langs/zh_CN.yml
@@ -140,7 +140,7 @@ world-list-changeda-via-command: "§f世界 §e%name%§f 已从§e 禁用世界�
 cant-add-member-anymore: "§c您已达到每个领地的最大成员数量。"
 you-cannot-use-this-name: "§c您不能在新的领地名称中使用 'claim-'。"
 incorrect-characters-name: "§c您必须使用仅包含字母和数字的名称。"
-incorrect-characters-description: "§c您必须使用仅包含字母和数字的描述。"
+incorrect-characters-description: "§c提供的描述包含非法字符。"
 claim-not-an-admin-claim: "§c此领地不是受保护区域。"
 not-using-database: "§c在 config.yml 中禁用了数据库。"
 member-limit-must-be-positive: "§c成员限制必须为正数。"

--- a/src/main/java/fr/xyness/SCS/Commands/ClaimCommand.java
+++ b/src/main/java/fr/xyness/SCS/Commands/ClaimCommand.java
@@ -229,7 +229,7 @@ public class ClaimCommand implements CommandExecutor, TabCompleter {
             	player.sendMessage(instance.getLanguage().getMessage("claim-description-too-long"));
                 return;
             }
-            if (!instance.getSettings().getDescriptionPattern().matcher(description).find()) {
+            if (!instance.getSettings().getDescriptionPatternClaims().matcher(description).find()) {
                 player.sendMessage(instance.getLanguage().getMessage("incorrect-characters-description"));
                 return;
             }

--- a/src/main/java/fr/xyness/SCS/Commands/ClaimCommand.java
+++ b/src/main/java/fr/xyness/SCS/Commands/ClaimCommand.java
@@ -229,7 +229,7 @@ public class ClaimCommand implements CommandExecutor, TabCompleter {
             	player.sendMessage(instance.getLanguage().getMessage("claim-description-too-long"));
                 return;
             }
-            if (!description.matches("^[a-zA-Z0-9\\s]+$")) {
+            if (!instance.getSettings().getDescriptionPattern().matcher(description).find()) {
                 player.sendMessage(instance.getLanguage().getMessage("incorrect-characters-description"));
                 return;
             }

--- a/src/main/java/fr/xyness/SCS/Commands/ProtectedAreaCommand.java
+++ b/src/main/java/fr/xyness/SCS/Commands/ProtectedAreaCommand.java
@@ -168,10 +168,10 @@ public class ProtectedAreaCommand implements CommandExecutor, TabCompleter {
             	player.sendMessage(instance.getLanguage().getMessage("claim-description-too-long"));
                 return;
             }
-            if (!description.matches("^[a-zA-Z0-9]+$")) {
-            	player.sendMessage(instance.getLanguage().getMessage("incorrect-characters-description"));
-            	return;
-            }
+			if (!instance.getSettings().getDescriptionPatternProtected().matcher(description).find()) {
+				player.sendMessage(instance.getLanguage().getMessage("incorrect-characters-description"));
+				return;
+			}
             Claim claim = instance.getMain().getProtectedAreaByName(args[1]);
             instance.getMain().setClaimDescription(claim, description)
             	.thenAccept(success -> {

--- a/src/main/java/fr/xyness/SCS/Commands/ProtectedAreaCommand.java
+++ b/src/main/java/fr/xyness/SCS/Commands/ProtectedAreaCommand.java
@@ -168,10 +168,10 @@ public class ProtectedAreaCommand implements CommandExecutor, TabCompleter {
             	player.sendMessage(instance.getLanguage().getMessage("claim-description-too-long"));
                 return;
             }
-			if (!instance.getSettings().getDescriptionPatternProtected().matcher(description).find()) {
-				player.sendMessage(instance.getLanguage().getMessage("incorrect-characters-description"));
-				return;
-			}
+            if (!instance.getSettings().getDescriptionPatternProtected().matcher(description).find()) {
+                player.sendMessage(instance.getLanguage().getMessage("incorrect-characters-description"));
+                return;
+            }
             Claim claim = instance.getMain().getProtectedAreaByName(args[1]);
             instance.getMain().setClaimDescription(claim, description)
             	.thenAccept(success -> {

--- a/src/main/java/fr/xyness/SCS/Config/ClaimSettings.java
+++ b/src/main/java/fr/xyness/SCS/Config/ClaimSettings.java
@@ -12,6 +12,7 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import fr.xyness.SCS.SimpleClaimSystem;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
@@ -87,8 +88,11 @@ public class ClaimSettings {
     /** Location of the expulsion */
     private Location expulsionLocation;
 
-    /** Regex for the description. */
-    private Pattern descriptionRegex;
+    /** Regex for the description of player claims. */
+    private Pattern descriptionRegexClaims;
+
+    /** Same, but for the protected areas. */
+    private Pattern descriptionRegexProtected;
 
     /** Default description pattern. Used if the user regex is not valid. */
     private static final Pattern DEFAULT_DESCRIPTION_PATTERN = Pattern.compile("^[a-zA-Z0-9\\s]+$");
@@ -116,7 +120,8 @@ public class ClaimSettings {
         groupsSettings.clear();
         worlds.clear();
         aliases.clear();
-        descriptionRegex = null;
+        descriptionRegexClaims = null;
+        descriptionRegexProtected = null;
     }
 
     /**
@@ -562,24 +567,34 @@ public class ClaimSettings {
     }
 
     /**
-     * Get the pattern for the default description.
+     * Get the pattern for the description of claims.
      * @return a non-null instance of a pattern. If the provided one is not valid, will use a default, safe one.
      */
-    public Pattern getDescriptionPattern() {
-        if(descriptionRegex == null) {
-            String regex = getSetting("description-regex");
-            if(regex.isEmpty()) {
-                instance.info("[ERROR] The claim-description regex is not set. Set the 'description-regex' property.");
-                return DEFAULT_DESCRIPTION_PATTERN;
-            }
-
-            try {
-                descriptionRegex = Pattern.compile(regex);
-            } catch(PatternSyntaxException e) {
-                instance.info("[ERROR] The claim-description regex (\""+regex+"\") is not valid: " + e.getDescription());
-                return DEFAULT_DESCRIPTION_PATTERN;
-            }
+    public Pattern getDescriptionPatternClaims() {
+        if(descriptionRegexClaims == null) {
+            descriptionRegexClaims = computeOrDefault("description-regex.claims");
         }
-        return descriptionRegex;
+        return descriptionRegexClaims;
+    }
+
+    /**
+     * Get the pattern for the description of protected-areas.
+     * @return a non-null instance of a pattern. If the provided one is not valid, will use a default, safe one.
+     */
+    public Pattern getDescriptionPatternProtected() {
+        if(descriptionRegexProtected == null) {
+            descriptionRegexProtected = computeOrDefault("description-regex.protected-areas");
+        }
+        return descriptionRegexProtected;
+    }
+
+    private Pattern computeOrDefault(String key) {
+        String regex = getSetting(key);
+        try {
+            return Pattern.compile(regex);
+        } catch(PatternSyntaxException e) {
+            instance.info(ChatColor.RED + "[ERROR] The property "+key+" (\""+regex+"\") is not valid: " + e.getMessage());
+            return DEFAULT_DESCRIPTION_PATTERN;
+        }
     }
 }

--- a/src/main/java/fr/xyness/SCS/Guis/AdminGestion/AdminGestionClaimsProtectedAreasGui.java
+++ b/src/main/java/fr/xyness/SCS/Guis/AdminGestion/AdminGestionClaimsProtectedAreasGui.java
@@ -232,7 +232,7 @@ public class AdminGestionClaimsProtectedAreasGui implements InventoryHolder {
      * @return The created ItemStack.
      */
     private ItemStack createClaimItem(Claim claim, Player player, List<String> lore) {
-        String displayName = "§6"+claim.getName()+" §7("+claim.getDescription()+")";
+        String displayName = "§6"+claim.getName()+" §7("+ChatColor.translateAlternateColorCodes('&', claim.getDescription())+"§7)";
         return createPlayerHeadItem(claim, displayName, lore);
     }
 

--- a/src/main/java/fr/xyness/SCS/Guis/ClaimListGui.java
+++ b/src/main/java/fr/xyness/SCS/Guis/ClaimListGui.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -250,7 +251,7 @@ public class ClaimListGui implements InventoryHolder {
 
         for (String s : lore) {
             s = s.replace("%owner%", owner)
-                 .replace("%description%", description)
+                 .replace("%description%", ChatColor.translateAlternateColorCodes('&', description))
                  .replace("%name%", name)
                  .replace("%coords%", coords);
 

--- a/src/main/java/fr/xyness/SCS/Guis/ClaimMainGui.java
+++ b/src/main/java/fr/xyness/SCS/Guis/ClaimMainGui.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -107,7 +108,7 @@ public class ClaimMainGui implements InventoryHolder {
     			String title = slot.getTitle();
     			String lore_string = slot.getLore();
     			if(key.equals("Info")) {
-    				title = title.replace("%description%", claim.getDescription())
+    				title = title.replace("%description%", ChatColor.translateAlternateColorCodes('&', claim.getDescription()))
     			    		.replace("%claim-name%", claim.getName())
     			    		.replace("%sale-status%", claim.getSale() ? (instance.getLanguage().getMessage("claim-info-lore-sale-status-true")
     							.replace("%price%", instance.getMain().getNumberSeparate(String.valueOf(claim.getPrice())))
@@ -115,7 +116,7 @@ public class ClaimMainGui implements InventoryHolder {
     			    		.replace("%chunks-count%", instance.getMain().getNumberSeparate(String.valueOf(claim.getChunks().size())))
     						.replace("%members-count%", instance.getMain().getNumberSeparate(String.valueOf(claim.getMembers().size())))
     						.replace("%bans-count%", instance.getMain().getNumberSeparate(String.valueOf(claim.getBans().size())));
-    				lore_string = lore_string.replace("%description%", claim.getDescription())
+    				lore_string = lore_string.replace("%description%", ChatColor.translateAlternateColorCodes('&', claim.getDescription()))
     			    		.replace("%claim-name%", claim.getName())
     			    		.replace("%sale-status%", claim.getSale() ? (instance.getLanguage().getMessage("claim-info-lore-sale-status-true")
     							.replace("%price%", instance.getMain().getNumberSeparate(String.valueOf(claim.getPrice())))

--- a/src/main/java/fr/xyness/SCS/Guis/ClaimsOwnerGui.java
+++ b/src/main/java/fr/xyness/SCS/Guis/ClaimsOwnerGui.java
@@ -223,7 +223,7 @@ public class ClaimsOwnerGui implements InventoryHolder {
     private List<String> prepareLore(List<String> template, Claim claim, Player player) {
         List<String> lore = new ArrayList<>();
         for (String line : template) {
-            line = line.replace("%description%", claim.getDescription())
+            line = line.replace("%description%", ChatColor.translateAlternateColorCodes('&', claim.getDescription()))
                 .replace("%name%", claim.getName())
                 .replace("%coords%", instance.getMain().getClaimCoords(claim));
             if (line.contains("%members%")) {

--- a/src/main/java/fr/xyness/SCS/SimpleClaimSystem.java
+++ b/src/main/java/fr/xyness/SCS/SimpleClaimSystem.java
@@ -776,7 +776,8 @@ public class SimpleClaimSystem extends JavaPlugin {
             claimSettingsInstance.addSetting("claims-visitors-off-visible", getConfig().getString("claims-visitors-off-visible"));
 
             // Description regex
-            claimSettingsInstance.addSetting("description-regex", getConfig().getString("description-regex"));
+            claimSettingsInstance.addSetting("description-regex.claims", getConfig().getString("description-regex.claims"));
+            claimSettingsInstance.addSetting("description-regex.protected-areas", getConfig().getString("description-regex.protected-areas"));
             
             // Check claim fly disabled or not for Folia
             if(isFolia) {

--- a/src/main/java/fr/xyness/SCS/SimpleClaimSystem.java
+++ b/src/main/java/fr/xyness/SCS/SimpleClaimSystem.java
@@ -244,7 +244,7 @@ public class SimpleClaimSystem extends JavaPlugin {
             } else {
             	claimInstance = new ClaimMain(this);
             	claimGuisInstance = new ClaimGuis(this);
-            	claimSettingsInstance = new ClaimSettings();
+            	claimSettingsInstance = new ClaimSettings(this);
             	cPlayerMainInstance = new CPlayerMain(this);
             	claimLanguageInstance = new ClaimLanguage(this);
             	claimBossBarInstance = new ClaimBossBar(this);
@@ -774,6 +774,9 @@ public class SimpleClaimSystem extends JavaPlugin {
             
             // Check if claims where Visitors is false are displayed in the /claims GUI
             claimSettingsInstance.addSetting("claims-visitors-off-visible", getConfig().getString("claims-visitors-off-visible"));
+
+            // Description regex
+            claimSettingsInstance.addSetting("description-regex", getConfig().getString("description-regex"));
             
             // Check claim fly disabled or not for Folia
             if(isFolia) {
@@ -1798,7 +1801,7 @@ public class SimpleClaimSystem extends JavaPlugin {
     
     /**
      * Reloads the language file.
-     * 
+     *
      * @param plugin The plugin instance
      * @param sender The command sender
      * @param lang The language file to reload

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -153,8 +153,11 @@ bossbar-settings:
   style: SOLID
 
 # A regular expression to control the allowed description of a claim.
-# The default value is '^[a-zA-Z0-9\s]+$' and only allows for alphanumerical strings, with spaces.
-description-regex: '^[a-zA-Z0-9\s]+$'
+# The default value for the player-claims is '^[a-zA-Z0-9\s]+$' and only allows for alphanumerical strings, with spaces.
+# The default value for the protected areas is the same, but will also include the color symbols.
+description-regex:
+  claims: '^[a-zA-Z0-9\s]+$'
+  protected-areas: '^[a-zA-Z0-9&#\s]+$'
 
 # If delay > 0, can the player move
 # true = can move, false = cannot move

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -152,6 +152,10 @@ bossbar-settings:
   color: YELLOW
   style: SOLID
 
+# A regular expression to control the allowed description of a claim.
+# The default value is '^[a-zA-Z0-9\s]+$' and only allows for alphanumerical strings, with spaces.
+description-regex: '^[a-zA-Z0-9\s]+$'
+
 # If delay > 0, can the player move
 # true = can move, false = cannot move
 teleportation-delay-moving: false

--- a/src/main/resources/langs/en_US.yml
+++ b/src/main/resources/langs/en_US.yml
@@ -138,7 +138,7 @@ world-list-changeda-via-command: "§fWorld §e%name%§f removed from §edisabled
 cant-add-member-anymore: "§cYou have reached the maximum number of members per claim."
 you-cannot-use-this-name: "§cYou cannot use 'claim-' in your new claim name."
 incorrect-characters-name: "§cYou must use a name with only letters and numbers."
-incorrect-characters-description: "§cYou must use a description with only letters and numbers."
+incorrect-characters-description: "§cThe provided description contains illegal characters."
 claim-not-an-admin-claim: "§cThis claim is not a protected area."
 not-using-database: "§cThe database is disabled in config.yml."
 member-limit-must-be-positive: "§cThe member limit must be positive."


### PR DESCRIPTION
# Current problem

The description must follow an hardcoded regular expression : `^[a-zA-Z0-9\s]+$`. This does not allow players to use their language. Neither accents nor special characters are allowed, and it is impossible to add colours, although this is technically allowed.

# Solution

Because the database already stores the description as a `VARCHAR(255)`, there is no reason to restrict the server admin to an alphanumerical string for all player claims. As such, we can simply add a configuration entry to specify a regex that should be allowed for players.

## Features :
1. Two new config entries: `description-regex.claims` and `description-regex.protected-areas`. As the name implies, each one of them defines a pattern the in-game users will have to follow.
    - Splitting the two of them may allow server-admin to restrict colors only for protected areas for example.
2. Every description (except the one in the chat when the description has ben changed) is now displayed with interpreted colours. Because the rest of the codebase uses `§` and `ChatColor`, the simplest way of doing so is with `ChatColor.translateAlternateColorCodes`.
3. Changed i18n entries in the `lang/` directory.