### PR TITLE
Don't unload PAPI expansion on reload

### DIFF
--- a/src/main/java/fr/xyness/SCS/Support/ClaimPlaceholdersExpansion.java
+++ b/src/main/java/fr/xyness/SCS/Support/ClaimPlaceholdersExpansion.java
@@ -65,6 +65,11 @@ public class ClaimPlaceholdersExpansion extends PlaceholderExpansion {
         return "1.0";
     }
 
+	@Override
+	public boolean persist() {
+		return true;
+	}
+
     @Override
     public String onPlaceholderRequest(Player player, String identifier) {
         if (player == null) return "";


### PR DESCRIPTION
Should fixe placeholders no longer working after running `/papi reload`