### PR TITLE
Claim settings are not being saved in the database due to wrong owner UUID determination

### DIFF
--- a/src/main/java/fr/xyness/SCS/ClaimMain.java
+++ b/src/main/java/fr/xyness/SCS/ClaimMain.java
@@ -2818,7 +2818,8 @@ public class ClaimMain {
                 if (permission.equals("Fly")) updateFlyChunk(claim);
                 
                 // Get the UUID of the owner
-                String uuid = owner.equals("*") ? SERVER_UUID.toString() : instance.getPlayerMain().getPlayerUUID(owner).toString();
+                //String uuid = owner.equals("*") ? SERVER_UUID.toString() : instance.getPlayerMain().getPlayerUUID(owner).toString();
+            	UUID uuid = claim.getUUID();
         
                 // Build the perms string
                 String permissions = claim.getPermissions().entrySet().stream()
@@ -2832,7 +2833,7 @@ public class ClaimMain {
                 try (Connection connection = instance.getDataSource().getConnection();
                      PreparedStatement preparedStatement = connection.prepareStatement(updateQuery)) {
                     preparedStatement.setString(1, permissions);
-                    preparedStatement.setString(2, uuid);
+                    preparedStatement.setString(2, uuid.toString());
                     preparedStatement.setString(3, claim.getName());
                     preparedStatement.executeUpdate();
                     return true;


### PR DESCRIPTION
In different places of the source code, the UUID of the claim owner seems to be determined in divergent ways.

In most places, like in `setClaimName` or `setClaimDescription` this is done as follows:
```
UUID uuid = claim.getUUID(); 
```
Internally, this just returns the claim's `uuid_owner` property

However, in `updatePerm` we see:
```
String uuid = owner.equals("*") ? SERVER_UUID.toString() : instance.getPlayerMain().getPlayerUUID(owner).toString();
```
This appears to be redundant, since the owner is already determined before and saved internally. Moreover, this seems to not always return the correct UUID.

I believe this line of code is legacy from an earlier state of the plugin. It can also be found in other places, so it might be worth revisiting this logic.

---

Context: I found that the plugin was not saving changes done through `/claim settings` in the database, despite there being no error messages or other fault indicators.

Since the permissions seemed to work up until server reboot, I figured `updatePerm` must have correctly executed `claim.getPermissions().put(roleKey, newPermissions);`. Since I could see no error messages, it must've meant that the SQL query is executed successfully. However, as I did not see any changes in the database, I figured that the `UPDATE` statement must not be affecting any rows at all. This could only be the case if the `WHERE` statement fails to find the affected claim, i.e., if the `owner_uuid` is being checked against an incorrect value.

This is clearly not the intended behavior, but it does not produce any errors or warnings. As such, I'd also recommend adding a warning message if an SQL query does not affect any rows against expectations.